### PR TITLE
Adding external sliding-action feature for easy-to-use navigation

### DIFF
--- a/src/Onboarding.jsx
+++ b/src/Onboarding.jsx
@@ -15,10 +15,6 @@ export default function Onboarding() {
     // button visibilty states
     const [previousButtonVisibilityRef, setPreviousButtonVisibility] = useState("none");
     const [nextButtonContentRef, setNextButtonContent] = useState("next");
-
-    // states to operate left/right slider action buttons
-    const [leftSlideActionRef, setLeftSlideAction] = useState(false);
-    const [rightSlideActionRef, setRightSlideAction] = useState(true);
     
     useEffect(() => {
         // fetching content to show in the modal
@@ -100,7 +96,7 @@ export default function Onboarding() {
                 </div> */}
                 {/* end: progress bar animation section wrapper */}
 
-                <div className="onboarding-popup-internal-content-wrapper p-6">
+                <div className="onboarding-popup-internal-content-wrapper cursor-default select-none p-6">
                     <div 
                         className="text-white text-lg font-medium" 
                         style={{
@@ -119,43 +115,51 @@ export default function Onboarding() {
                         <div 
                             className="onboarding-feature-screenshots-wrapper 
                                 mt-3 w-auto py-3 h-fit max-h-[400px] overflow-hidden
-                                flex flex-row items-center justify-start gap-3
+                                flex flex-row items-center justify-start gap-3 relative
+                                cursor-default select-none
                             "
                         >
-                            {!currentOnboardingViewRef && currentOnboardingViewRef === 0
-                                ? <React.Fragment></React.Fragment>
-                                : <button
-                                    id="slider-slide_left" 
-                                    className="p-2 rounded-full bg-zinc-600 opacity-50 shadow-lg hover:opacity-60 hover:shadow-2xl"
-                                    onClick={() => {
-                                        if (currentOnboardingViewRef && currentOnboardingViewRef !== 0) {
-                                            setCurrentOnboardingView(currentOnboardingViewRef - 1);
-                                        }
-                                    }}
-                                >
-                                    <FaArrowLeft className="text-white text-opacity-60" />
-                                </button>
-                            }
                             <img 
                                 src={contentForOnboardingRef.content.featureScreenshot}
                                 alt={contentForOnboardingRef.content.featureTitle.toString().toLowerCase()}
                                 id={contentForOnboardingRef.content.featureTitle.toString().toLowerCase()}
                                 className="mx-auto"
                             />
-                            {currentOnboardingViewRef === contentForOnboardingRef.totalSlideCount
-                                ? <React.Fragment></React.Fragment>
-                                : <button
-                                    id="slider-slide_right" 
-                                    className="p-2 rounded-full bg-zinc-600 opacity-50 shadow-lg hover:opacity-60 hover:shadow-2xl"
-                                    onClick={() => {
-                                        if (currentOnboardingViewRef < contentForOnboardingRef.totalSlideCount) {
-                                            setCurrentOnboardingView(currentOnboardingViewRef + 1);
-                                        }
-                                    }}
-                                >
-                                    <FaArrowRight className="text-white text-opacity-60" />
-                                </button>
-                            } 
+                            <div 
+                                className="slider-action-button-layer-wrapper p-3 flex flex-row items-center justify-between mx-auto w-full h-fit absolute"
+                                style={{
+                                    right: '0px',
+                                }}
+                            >
+                                {!currentOnboardingViewRef && currentOnboardingViewRef === 0
+                                    ? <span className="opacity-0 cursor-default">left-button-placeholder</span>
+                                    : <button
+                                        id="slider-slide_left" 
+                                        className="slider_slide-action-button p-2 rounded-full bg-zinc-600 shadow-lg hover:shadow-2xl"
+                                        onClick={() => {
+                                            if (currentOnboardingViewRef && currentOnboardingViewRef !== 0) {
+                                                setCurrentOnboardingView(currentOnboardingViewRef - 1);
+                                            }
+                                        }}
+                                    >
+                                        <FaArrowLeft className="text-white text-opacity-60" />
+                                    </button>
+                                }
+                                {currentOnboardingViewRef === contentForOnboardingRef.totalSlideCount
+                                    ? <React.Fragment></React.Fragment>
+                                    : <button
+                                        id="slider-slide_right" 
+                                        className="slider_slide-action-button p-2 rounded-full bg-zinc-600 shadow-lg hover:shadow-2xl"
+                                        onClick={() => {
+                                            if (currentOnboardingViewRef < contentForOnboardingRef.totalSlideCount) {
+                                                setCurrentOnboardingView(currentOnboardingViewRef + 1);
+                                            }
+                                        }}
+                                    >
+                                        <FaArrowRight className="text-white text-opacity-60" />
+                                    </button>
+                                }
+                            </div>
                         </div>
                         <div className="navigation-component-wrapper">
                             {/* 

--- a/src/Onboarding.jsx
+++ b/src/Onboarding.jsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from "react";
 import ReactModal from "react-modal";
+import { FaArrowLeft, FaArrowRight } from 'react-icons/fa';
 
 ReactModal.setAppElement('#root');
 
@@ -14,6 +15,10 @@ export default function Onboarding() {
     // button visibilty states
     const [previousButtonVisibilityRef, setPreviousButtonVisibility] = useState("none");
     const [nextButtonContentRef, setNextButtonContent] = useState("next");
+
+    // states to operate left/right slider action buttons
+    const [leftSlideActionRef, setLeftSlideAction] = useState(false);
+    const [rightSlideActionRef, setRightSlideAction] = useState(true);
     
     useEffect(() => {
         // fetching content to show in the modal
@@ -99,7 +104,7 @@ export default function Onboarding() {
                     <div 
                         className="text-white text-lg font-medium" 
                         style={{
-                            width: '720px',
+                            width: 'fit-content',
                             height: 'fit-content'
                         }}
                     >
@@ -114,29 +119,54 @@ export default function Onboarding() {
                         <div 
                             className="onboarding-feature-screenshots-wrapper 
                                 mt-3 w-auto py-3 h-fit max-h-[400px] overflow-hidden
-                                flex flex-row items-center justify-start gap-2
+                                flex flex-row items-center justify-start gap-3
                             "
                         >
+                            {!currentOnboardingViewRef && currentOnboardingViewRef === 0
+                                ? <React.Fragment></React.Fragment>
+                                : <button
+                                    id="slider-slide_left" 
+                                    className="p-2 rounded-full bg-zinc-600 opacity-50 shadow-lg hover:opacity-60 hover:shadow-2xl"
+                                    onClick={() => {
+                                        if (currentOnboardingViewRef && currentOnboardingViewRef !== 0) {
+                                            setCurrentOnboardingView(currentOnboardingViewRef - 1);
+                                        }
+                                    }}
+                                >
+                                    <FaArrowLeft className="text-white text-opacity-60" />
+                                </button>
+                            }
                             <img 
                                 src={contentForOnboardingRef.content.featureScreenshot}
                                 alt={contentForOnboardingRef.content.featureTitle.toString().toLowerCase()}
                                 id={contentForOnboardingRef.content.featureTitle.toString().toLowerCase()}
                                 className="mx-auto"
                             />
+                            {currentOnboardingViewRef === contentForOnboardingRef.totalSlideCount
+                                ? <React.Fragment></React.Fragment>
+                                : <button
+                                    id="slider-slide_right" 
+                                    className="p-2 rounded-full bg-zinc-600 opacity-50 shadow-lg hover:opacity-60 hover:shadow-2xl"
+                                    onClick={() => {
+                                        if (currentOnboardingViewRef < contentForOnboardingRef.totalSlideCount) {
+                                            setCurrentOnboardingView(currentOnboardingViewRef + 1);
+                                        }
+                                    }}
+                                >
+                                    <FaArrowRight className="text-white text-opacity-60" />
+                                </button>
+                            } 
                         </div>
                         <div className="navigation-component-wrapper">
                             {/* 
                                 Legacy implementation for showing navigation slider,
                                 currently, it's not working but saving it for future references
                             */}
-
-                            
                                 <ShowSlideNavigation 
                                     totalSlideCount={contentForOnboardingRef.totalSlideCount} 
                                     activeSlideIndex={currentOnboardingViewRef+1}
                                     updateActiveSlideIndexMethod={setCurrentOnboardingView}   
                                 /> 
-                           
                         </div>
                     </div>
                     <div className="button-slots-wrapper mt-4 flex flex-row items-center justify-between">

--- a/src/index.css
+++ b/src/index.css
@@ -32,3 +32,18 @@ body {
 *::-webkit-scrollbar-thumb:hover {
     background: #555;
 }
+
+
+/* css dump for slider_slide-action-button */
+
+.onboarding-feature-screenshots-wrapper 
+    > .slider-action-button-layer-wrapper 
+        > .slider_slide-action-button {
+            opacity: 10%;
+}
+
+.onboarding-feature-screenshots-wrapper:hover 
+    > .slider-action-button-layer-wrapper 
+        > .slider_slide-action-button {
+            opacity: 50%;
+}


### PR DESCRIPTION
Creating a more better UX for sliding and navigating between the slides in the onboarding-popup.

**UX and Controlling features it is going to have**

- [x] Sliding arrow buttons
  - [x] Should come when hovering the feature-demo image
  - [x] Should inherit the slide-navigating properties like the bottom-action buttons
- [ ] Should come on top of the feature-demo image

Here's a explanation for implementing the layers for these action-buttons.

![image](https://user-images.githubusercontent.com/62352288/177799923-c98d4162-9898-4e16-84a6-ee87fad0dbce.png)
